### PR TITLE
fix: allow scalar values for env args of scripts in `melos.yaml`

### DIFF
--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -94,7 +94,7 @@
                 "type": "object",
                 "description": "Environment variables that will be passed to the command to execute.",
                 "additionalProperties": {
-                  "type": "string",
+                  "type": ["string", "number", "integer", "boolean", "null"],
                   "description": "The value of the environment variable."
                 }
               },

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -94,7 +94,13 @@
                 "type": "object",
                 "description": "Environment variables that will be passed to the command to execute.",
                 "additionalProperties": {
-                  "type": ["string", "number", "integer", "boolean", "null"],
+                  "anyOf": [
+                    { "type": "string" },
+                    { "type": "number" },
+                    { "type": "integer" },
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ],
                   "description": "The value of the environment variable."
                 }
               },

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -9,7 +9,7 @@ export function run(testsRoot: string): Promise<void> {
   const mocha = new Mocha({
     ui: 'tdd',
     color: true,
-    timeout: 10000,
+    timeout: 30000,
   })
 
   return new Promise((c, e) => {


### PR DESCRIPTION
Fixes #18