### PR TITLE
feat: add editor title menu entries for `melos.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "command": "melos.bootstrap",
         "title": "Bootstrap",
         "category": "Melos",
+        "icon": "$(package)",
         "enablement": "shellExecutionSupported && workspaceFolderCount > 0"
       },
       {
@@ -84,9 +85,24 @@
         "command": "melos.showPackageGraph",
         "title": "Show package graph",
         "category": "Melos",
+        "icon": "$(circuit-board)",
         "enablement": "shellExecutionSupported && workspaceFolderCount > 0"
       }
-    ]
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "melos.showPackageGraph",
+          "when": "resourceFilename == melos.yaml",
+          "group": "navigation"
+        },
+        {
+          "command": "melos.bootstrap",
+          "when": "resourceFilename == melos.yaml",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "extensionDependencies": [
     "redhat.vscode-yaml",


### PR DESCRIPTION
When `melos.yaml` is open in the editor, a menu entry for
`melos.bootstrap` and `melos.showPackageGraph` is added
to the editor title menu.

Fixes #20