### PR TITLE
fix: only run melos script in selected package

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -175,14 +175,17 @@ function runScriptCommandHandler(context: vscode.ExtensionContext) {
           title: 'Select package to run script in',
         }
       )
+
       if (!selectedPackage) {
         // User did not select a package.
         return
       }
+
       if (!selectedPackage.pkg) {
-        // Run in all packages.
+        // User wants to run the script in all packages.
         return runMelosScriptTask()
       }
+
       packageName = selectedPackage.pkg.name
     }
 
@@ -195,17 +198,16 @@ function runScriptCommandHandler(context: vscode.ExtensionContext) {
     }
 
     // Execute the script in a single package.
-    return vscode.tasks.executeTask(
-      buildMelosExecScriptTask(
-        {
-          type: 'melos',
-          script: scriptConfig!.name.value,
-          execOptions: ['--scope', packageName, ...melosExecCommand.options],
-          command: melosExecCommand.command,
-        },
-        workspaceFolder
-      )
+    const task = buildMelosExecScriptTask(
+      {
+        type: 'melos',
+        script: `${scriptConfig!.name.value} [${packageName}]`,
+        execOptions: ['--scope', packageName, ...melosExecCommand.options],
+        command: melosExecCommand.command,
+      },
+      workspaceFolder
     )
+    return vscode.tasks.executeTask(task)
   }
 }
 


### PR DESCRIPTION
Previously the VS Code task for running a script in all packages and task for
running the script in a single package had the same name. Because of task
caching the task running in all package was always executed.
Now every task has a unique name.