### PR TITLE
docs: add installation section to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 This extension adds support for using [Melos] with Visual Studio Code.
 
 ## Installation
+
 Melos Code can be [installed from the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=blaugold.melos-code) or by [searching within VS Code](https://code.visualstudio.com/docs/editor/extension-gallery#_search-for-an-extension).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 This extension adds support for using [Melos] with Visual Studio Code.
 
+## Installation
+Melos Code can be [installed from the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=blaugold.melos-code) or by [searching within VS Code](https://code.visualstudio.com/docs/editor/extension-gallery#_search-for-an-extension).
+
 ## Features
 
 - Validation and autocompletion of `melos.yaml`


### PR DESCRIPTION
I found this GitHub repository, but couldn't find a button to install this extension. 

Copied the style from [Dart Code](https://github.com/Dart-Code/Dart-Code).