### PR TITLE
feat: add `ide.intellij.enabled` and `command.version.releaseUrl` to `melos.yaml` schema

### DIFF
--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -44,6 +44,10 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Whether IntelliJ support is enabled."
+                },
                 "moduleNamePrefix": {
                   "type": "string",
                   "description": "Used when generating IntelliJ project modules files, this value specifies a string to prepend to a package's IntelliJ module name.\n\nThe default is 'melos_'."

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -102,6 +102,10 @@
             "updateGitTagRefs": {
               "type": "boolean",
               "description": "Whether to also update pubspec with git referenced packages."
+            },
+            "releaseUrl": {
+              "type": "boolean",
+              "description": "Whether to generate and print a link to the prefilled release creation page for each package after versioning.\n\nDisabled by default."
             }
           }
         }


### PR DESCRIPTION
On a side note, wouldn't it be better to distribute the schema file together with Melos itself? That way it could also be used by IntelliJ & co. and it would allow always using the version shipped with the currently active Melos version by pointing at the schema file in the pub cache.