### PR TITLE
ci: update `actions/checkout` from v2 to v3 in our GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
Node 12 is deprecated for GitHub Actions. This is the reason why GitHub shows us a warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates `actions/checkout` from v2 to v3 which should fix the problem.