### PR TITLE
feat: add `runPubGetOffline` and `runPubGetOffline` to melos.yaml schema

### DIFF
--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -101,9 +101,20 @@
               "type": "boolean",
               "description": "Whether to run `pub get` in parallel during bootstrapping."
             },
+            "runPubGetOffline": {
+              "type": "boolean",
+              "description": "Whether to attempt to run `pub get` in offline mode during bootstrapping."
+            },
             "hooks": {
               "description": "Hooks to run at certain points of the command lifecycle.",
               "allOf": [{ "$ref": "#/$defs/commonHooks" }]
+            },
+            "dependencyOverridePaths": {
+              "type": "array",
+              "description": "A list of paths to local packages relative to the workspace directory that should be added to each workspace package's dependency overrides. Each entry can be a specific path or a glob pattern.",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },


### PR DESCRIPTION
The bootstrap command, specifically runPubGetOffline and dependencyOverridePaths. See the latest documentation for reference: https://github.com/invertase/melos/blob/2f19770eee9deff097d26202bece72bd6b2127a1/docs/configuration/overview.mdx